### PR TITLE
refactor(foundation): compact table names into single env var

### DIFF
--- a/examples/subscription-webhooks/__generated__/enricher--subscription-event--upsert--account/handler.ts
+++ b/examples/subscription-webhooks/__generated__/enricher--subscription-event--upsert--account/handler.ts
@@ -1,5 +1,8 @@
 // This file is generated. Do not edit by hand.
-import {makeEnricher} from '@code-like-a-carpenter/foundation-runtime';
+import {
+  expandTableNames,
+  makeEnricher,
+} from '@code-like-a-carpenter/foundation-runtime';
 
 import {SubscriptionEventUpsertAccountEnricher} from '../../src/enrich--subscription--upsert--account';
 import type {
@@ -13,6 +16,9 @@ import {
   unmarshallSubscriptionEvent,
   updateAccount,
 } from '../graphql';
+
+expandTableNames();
+
 export const handler = makeEnricher<
   SubscriptionEvent,
   Account,

--- a/examples/subscription-webhooks/__generated__/react--account--upsert/handler.ts
+++ b/examples/subscription-webhooks/__generated__/react--account--upsert/handler.ts
@@ -1,9 +1,15 @@
 // This file is generated. Do not edit by hand.
-import {makeReactor} from '@code-like-a-carpenter/foundation-runtime';
+import {
+  expandTableNames,
+  makeReactor,
+} from '@code-like-a-carpenter/foundation-runtime';
 
 import {AccountUpsertReactor} from '../../src/react--account--upsert';
 import {unmarshallAccount} from '../graphql';
 import type {Account} from '../graphql';
+
+expandTableNames();
+
 export const handler = makeReactor<Account>(AccountUpsertReactor, {
   unmarshallSourceModel: unmarshallAccount,
 });

--- a/examples/subscription-webhooks/__generated__/react--plan-metric--upsert/handler.ts
+++ b/examples/subscription-webhooks/__generated__/react--plan-metric--upsert/handler.ts
@@ -1,9 +1,15 @@
 // This file is generated. Do not edit by hand.
-import {makeReactor} from '@code-like-a-carpenter/foundation-runtime';
+import {
+  expandTableNames,
+  makeReactor,
+} from '@code-like-a-carpenter/foundation-runtime';
 
 import {PlanMetricUpsertReactor} from '../../src/react--plan-metric--upsert';
 import {unmarshallPlanMetric} from '../graphql';
 import type {PlanMetric} from '../graphql';
+
+expandTableNames();
+
 export const handler = makeReactor<PlanMetric>(PlanMetricUpsertReactor, {
   unmarshallSourceModel: unmarshallPlanMetric,
 });

--- a/examples/subscription-webhooks/__generated__/template.yml
+++ b/examples/subscription-webhooks/__generated__/template.yml
@@ -8,14 +8,16 @@ Globals:
   Function:
     Environment:
       Variables:
-        TABLE_ACCOUNT:
-          Ref: 'TableAccount'
-        TABLE_METRIC:
-          Ref: 'TableMetric'
-        TABLE_PLAN_METRIC:
-          Ref: 'TablePlanMetric'
-        TABLE_SUBSCRIPTION_EVENT:
-          Ref: 'TableSubscriptionEvent'
+        FOUNDATION_TABLE_NAMES:
+          Fn::ToJsonString:
+            TABLE_ACCOUNT:
+              Ref: 'TableAccount'
+            TABLE_METRIC:
+              Ref: 'TableMetric'
+            TABLE_PLAN_METRIC:
+              Ref: 'TablePlanMetric'
+            TABLE_SUBSCRIPTION_EVENT:
+              Ref: 'TableSubscriptionEvent'
     Handler: 'index.handler'
     MemorySize: 256
     Runtime: 'nodejs18.x'
@@ -916,4 +918,6 @@ Resources:
       RetentionInDays:
         Ref: 'LogRetentionInDays'
     Type: 'AWS::Logs::LogGroup'
-Transform: 'AWS::Serverless-2016-10-31'
+Transform:
+  - 'AWS::Serverless-2016-10-31'
+  - 'AWS::LanguageExtensions'

--- a/examples/user-session/__generated__/template.yml
+++ b/examples/user-session/__generated__/template.yml
@@ -8,8 +8,10 @@ Globals:
   Function:
     Environment:
       Variables:
-        TABLE_USER_SESSION:
-          Ref: 'TableUserSession'
+        FOUNDATION_TABLE_NAMES:
+          Fn::ToJsonString:
+            TABLE_USER_SESSION:
+              Ref: 'TableUserSession'
     Handler: 'index.handler'
     MemorySize: 256
     Runtime: 'nodejs18.x'
@@ -64,4 +66,6 @@ Resources:
         AttributeName: 'ttl'
         Enabled: true
     Type: 'AWS::DynamoDB::Table'
-Transform: 'AWS::Serverless-2016-10-31'
+Transform:
+  - 'AWS::Serverless-2016-10-31'
+  - 'AWS::LanguageExtensions'

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,10 +110,13 @@
         "@aws-sdk/client-dynamodb": "3.188.0",
         "@aws-sdk/lib-dynamodb": "3.188.0",
         "@aws-sdk/smithy-client": "3.188.0",
+        "@aws-sdk/util-dynamodb": "3.188.0",
+        "@code-like-a-carpenter/assert": "*",
         "@code-like-a-carpenter/foundation-cli": "*",
         "@code-like-a-carpenter/foundation-runtime": "*",
         "@code-like-a-carpenter/wait-for": "*",
-        "@faker-js/faker": "^7.6.0"
+        "@faker-js/faker": "^7.6.0",
+        "base64url": "^3.0.1"
       },
       "engines": {
         "node": "18.x",
@@ -24057,6 +24060,7 @@
         "@code-like-a-carpenter/env": "*",
         "@code-like-a-carpenter/errors": "*",
         "@code-like-a-carpenter/exception": "*",
+        "@code-like-a-carpenter/logger": "*",
         "@opentelemetry/api": "1.4.0",
         "@opentelemetry/sdk-trace-base": "^1.9.1",
         "@sentry/serverless": "^7.40.0",

--- a/packages/@code-like-a-carpenter/foundation-plugin-cloudformation/src/cdc/enricher.ts
+++ b/packages/@code-like-a-carpenter/foundation-plugin-cloudformation/src/cdc/enricher.ts
@@ -24,7 +24,7 @@ export function defineEnricher(
   } = cdc;
 
   const template = `// This file is generated. Do not edit by hand.
-import {makeEnricher} from '${runtimeModuleId}';
+import {expandTableNames,makeEnricher} from '${runtimeModuleId}';
 import {${handlerImportName}} from '${handlerModuleId}';
 import {
   ${sourceModelName},
@@ -35,6 +35,9 @@ import {
   Create${targetModelName}Input,
   Update${targetModelName}Input
 } from '${actionsModuleId}';
+
+expandTableNames();
+
 export const handler = makeEnricher<
 ${sourceModelName},
 ${targetModelName},

--- a/packages/@code-like-a-carpenter/foundation-plugin-cloudformation/src/cdc/reactor.ts
+++ b/packages/@code-like-a-carpenter/foundation-plugin-cloudformation/src/cdc/reactor.ts
@@ -23,9 +23,12 @@ export function defineReactor(
   } = cdc;
 
   const code = `// This file is generated. Do not edit by hand.
-import {makeReactor} from '${runtimeModuleId}';
+import {expandTableNames, makeReactor} from '${runtimeModuleId}';
 import {${handlerImportName}} from '${handlerModuleId}';
 import type {${sourceModelName}, unmarshall${sourceModelName}} from '${actionsModuleId}';
+
+expandTableNames();
+
 export const handler = makeReactor<${sourceModelName}>(${handlerImportName}, {unmarshallSourceModel: unmarshall${sourceModelName}});
 `;
 

--- a/packages/@code-like-a-carpenter/foundation-plugin-cloudformation/src/plugin.ts
+++ b/packages/@code-like-a-carpenter/foundation-plugin-cloudformation/src/plugin.ts
@@ -37,7 +37,7 @@ function getInitialTemplate({
   return {
     AWSTemplateFormatVersion: '2010-09-09',
     Resources: {},
-    Transform: 'AWS::Serverless-2016-10-31',
+    Transform: ['AWS::Serverless-2016-10-31', 'AWS::LanguageExtensions'],
   };
 }
 
@@ -117,6 +117,20 @@ export const plugin: PluginFunction<Config> = makePlugin(
         ...allResources.Resources,
       },
     };
+
+    const variables = tpl?.Globals?.Function?.Environment?.Variables ?? {};
+
+    const tablesNames = Object.keys(variables)
+      .filter((name) => name.startsWith('TABLE_'))
+      .reduce((acc, name) => {
+        acc[name] = variables[name];
+        delete variables[name];
+        return acc;
+      }, {} as Record<string, string>);
+
+    if (Object.keys(tablesNames).length) {
+      variables.FOUNDATION_TABLE_NAMES = {'Fn::ToJsonString': tablesNames};
+    }
 
     const {format} = config.outputConfig;
     if (format === 'json') {

--- a/packages/@code-like-a-carpenter/foundation-runtime/src/expand-table-names.ts
+++ b/packages/@code-like-a-carpenter/foundation-runtime/src/expand-table-names.ts
@@ -1,0 +1,15 @@
+import {assert} from '@code-like-a-carpenter/assert';
+
+export function expandTableNames() {
+  const tableNames = process.env.FOUNDATION_TABLE_NAMES;
+  if (tableNames) {
+    const tables = JSON.parse(tableNames);
+    for (const [key, value] of Object.entries(tables)) {
+      assert(
+        typeof value === 'string',
+        'FOUNDATION_TABLE_NAMES should only contain string values'
+      );
+      process.env[key] = value;
+    }
+  }
+}

--- a/packages/@code-like-a-carpenter/foundation-runtime/src/index.ts
+++ b/packages/@code-like-a-carpenter/foundation-runtime/src/index.ts
@@ -1,3 +1,4 @@
+export * from './expand-table-names';
 export * from './field-provider';
 export * from './functions/enricher';
 export * from './functions/reactor';

--- a/packages/@code-like-a-carpenter/telemetry/package.json
+++ b/packages/@code-like-a-carpenter/telemetry/package.json
@@ -27,6 +27,7 @@
     "@code-like-a-carpenter/env": "*",
     "@code-like-a-carpenter/errors": "*",
     "@code-like-a-carpenter/exception": "*",
+    "@code-like-a-carpenter/logger": "*",
     "@opentelemetry/api": "1.4.0",
     "@opentelemetry/sdk-trace-base": "^1.9.1",
     "@sentry/serverless": "^7.40.0",

--- a/packages/@code-like-a-carpenter/telemetry/src/exceptions.ts
+++ b/packages/@code-like-a-carpenter/telemetry/src/exceptions.ts
@@ -11,6 +11,8 @@ import {
 import {snakeCase} from 'snake-case';
 
 import {Exception} from '@code-like-a-carpenter/exception';
+import type {Logger} from '@code-like-a-carpenter/logger';
+import {logger as rootLogger} from '@code-like-a-carpenter/logger';
 
 import {getCurrentSpan} from './run-with';
 
@@ -79,8 +81,14 @@ function addExceptionDetails(err: unknown, span?: Span, scope?: Scope) {
  * @param e - the exception to capture
  * @param escaped - Indicates if the error was unhandled. In general, this will
  * be true until the exception reaches a catch block and is not rethrown.
+ * @param logger - optional logger to use when OpenTelemetry is not in use. If
+ * not supplied, the default CLC logger will be used
  */
-export function captureException(e: unknown, escaped = true): Error {
+export function captureException(
+  e: unknown,
+  escaped = true,
+  logger: Logger = rootLogger
+): Error {
   const err = reformError(e);
   const span = getCurrentSpan();
 
@@ -88,6 +96,13 @@ export function captureException(e: unknown, escaped = true): Error {
     span.setStatus({code: SpanStatusCode.ERROR, message: err.message});
     span.recordException(err);
     span.setAttribute('exception.escaped', escaped);
+  } else {
+    // If we don't have a span, assume OpenTelemetry has not been configured, so
+    // we want to log instead of suppressing the error.
+    logger.error(
+      'Logging error message because OpenTelemetry does not appear to be in use',
+      {err: e}
+    );
   }
 
   if (escaped) {

--- a/packages/@code-like-a-carpenter/telemetry/tsconfig.json
+++ b/packages/@code-like-a-carpenter/telemetry/tsconfig.json
@@ -17,6 +17,9 @@
     },
     {
       "path": "../exception"
+    },
+    {
+      "path": "../logger"
     }
   ]
 }


### PR DESCRIPTION
There is a somewhere terrible hack to prepare for nested stacks. CloudFormation
makes it pretty much impossible to pass lists to nested stacks _and operate on
them_, so environment variables of indeterminate size need to be singly-
addressable
