### PR TITLE
proper test balancing

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -125,8 +125,8 @@ jobs:
       matrix:
         # There should be one node for each example, but at time of writing,
         # two of the examples are disabled due to issues with localstack.
-        nodeCount: [1]
-        nodeIndex: [0]
+        nodeCount: [3]
+        nodeIndex: [0, 1, 2]
     steps:
       - uses: actions/checkout@v3.5.0
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -125,8 +125,8 @@ jobs:
       matrix:
         # There should be one node for each example, but at time of writing,
         # two of the examples are disabled due to issues with localstack.
-        nodeCount: [3]
-        nodeIndex: [0, 1, 2]
+        nodeCount: [5]
+        nodeIndex: [0, 1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v3.5.0
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,6 +10,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3.5.0
         with:
@@ -25,6 +26,7 @@ jobs:
   diff:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3.5.0
         with:
@@ -44,6 +46,7 @@ jobs:
   lint:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3.5.0
         with:
@@ -85,6 +88,9 @@ jobs:
       - lint
       - test
     runs-on: ubuntu-latest
+    # This job gets exponentially slower based on the number of packages that
+    # need to be release, so 60 is not unreasonable.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3.5.0
         with:
@@ -120,6 +126,7 @@ jobs:
       id-token: write
       contents: read
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
CRR is struggling to handle submissions shards from different github action runners, so I turned off test distribution. Unfortunately, that manes that the suite, with AWS stack tests, takes over 20 minutes to run. This is not ok. This PR reenables distributed testing so I can poke at CRR to figure out what's going wrong.


