### PR TITLE
feat(foundation): support passing env vars to nested stacks (kinda)

### DIFF
--- a/examples/subscription-webhooks/__generated__/cdc.yml
+++ b/examples/subscription-webhooks/__generated__/cdc.yml
@@ -77,6 +77,9 @@ Parameters:
     Type: 'String'
   DetailType:
     Type: 'CommaDelimitedList'
+  EnvironmentVariables:
+    Default: ''
+    Type: 'String'
   LogRetentionInDays:
     Default: '3'
     Description: 'Log retention in days'

--- a/examples/subscription-webhooks/__generated__/dispatcher-table-account/handler.ts
+++ b/examples/subscription-webhooks/__generated__/dispatcher-table-account/handler.ts
@@ -1,13 +1,13 @@
 // This file is generated. Do not edit by hand.
 
 import {
-  expandTableNames,
+  expandEnvironmentVariables,
   makeDynamoDBStreamDispatcher,
 } from '@code-like-a-carpenter/foundation-runtime';
 
 import * as dependencies from '../../../dependencies';
 
-expandTableNames();
+expandEnvironmentVariables();
 
 export const handler = makeDynamoDBStreamDispatcher({
   ...dependencies,

--- a/examples/subscription-webhooks/__generated__/dispatcher-table-plan-metric/handler.ts
+++ b/examples/subscription-webhooks/__generated__/dispatcher-table-plan-metric/handler.ts
@@ -1,13 +1,13 @@
 // This file is generated. Do not edit by hand.
 
 import {
-  expandTableNames,
+  expandEnvironmentVariables,
   makeDynamoDBStreamDispatcher,
 } from '@code-like-a-carpenter/foundation-runtime';
 
 import * as dependencies from '../../../dependencies';
 
-expandTableNames();
+expandEnvironmentVariables();
 
 export const handler = makeDynamoDBStreamDispatcher({
   ...dependencies,

--- a/examples/subscription-webhooks/__generated__/dispatcher-table-subscription-event/handler.ts
+++ b/examples/subscription-webhooks/__generated__/dispatcher-table-subscription-event/handler.ts
@@ -1,13 +1,13 @@
 // This file is generated. Do not edit by hand.
 
 import {
-  expandTableNames,
+  expandEnvironmentVariables,
   makeDynamoDBStreamDispatcher,
 } from '@code-like-a-carpenter/foundation-runtime';
 
 import * as dependencies from '../../../dependencies';
 
-expandTableNames();
+expandEnvironmentVariables();
 
 export const handler = makeDynamoDBStreamDispatcher({
   ...dependencies,

--- a/examples/subscription-webhooks/__generated__/dispatcher.yml
+++ b/examples/subscription-webhooks/__generated__/dispatcher.yml
@@ -25,6 +25,9 @@ Parameters:
     Type: 'Number'
   CodeUri:
     Type: 'String'
+  EnvironmentVariables:
+    Default: ''
+    Type: 'String'
   EventBus:
     Type: 'String'
   LogRetentionInDays:

--- a/examples/subscription-webhooks/__generated__/enricher--subscription-event--upsert--account/handler.ts
+++ b/examples/subscription-webhooks/__generated__/enricher--subscription-event--upsert--account/handler.ts
@@ -1,6 +1,6 @@
 // This file is generated. Do not edit by hand.
 import {
-  expandTableNames,
+  expandEnvironmentVariables,
   makeEnricher,
 } from '@code-like-a-carpenter/foundation-runtime';
 
@@ -17,7 +17,7 @@ import {
   updateAccount,
 } from '../graphql';
 
-expandTableNames();
+expandEnvironmentVariables();
 
 export const handler = makeEnricher<
   SubscriptionEvent,

--- a/examples/subscription-webhooks/__generated__/react--account--upsert/handler.ts
+++ b/examples/subscription-webhooks/__generated__/react--account--upsert/handler.ts
@@ -1,6 +1,6 @@
 // This file is generated. Do not edit by hand.
 import {
-  expandTableNames,
+  expandEnvironmentVariables,
   makeReactor,
 } from '@code-like-a-carpenter/foundation-runtime';
 
@@ -8,7 +8,7 @@ import {AccountUpsertReactor} from '../../src/react--account--upsert';
 import {unmarshallAccount} from '../graphql';
 import type {Account} from '../graphql';
 
-expandTableNames();
+expandEnvironmentVariables();
 
 export const handler = makeReactor<Account>(AccountUpsertReactor, {
   unmarshallSourceModel: unmarshallAccount,

--- a/examples/subscription-webhooks/__generated__/react--plan-metric--upsert/handler.ts
+++ b/examples/subscription-webhooks/__generated__/react--plan-metric--upsert/handler.ts
@@ -1,6 +1,6 @@
 // This file is generated. Do not edit by hand.
 import {
-  expandTableNames,
+  expandEnvironmentVariables,
   makeReactor,
 } from '@code-like-a-carpenter/foundation-runtime';
 
@@ -8,7 +8,7 @@ import {PlanMetricUpsertReactor} from '../../src/react--plan-metric--upsert';
 import {unmarshallPlanMetric} from '../graphql';
 import type {PlanMetric} from '../graphql';
 
-expandTableNames();
+expandEnvironmentVariables();
 
 export const handler = makeReactor<PlanMetric>(PlanMetricUpsertReactor, {
   unmarshallSourceModel: unmarshallPlanMetric,

--- a/packages/@code-like-a-carpenter/foundation-plugin-cloudformation/src/cdc/enricher.ts
+++ b/packages/@code-like-a-carpenter/foundation-plugin-cloudformation/src/cdc/enricher.ts
@@ -24,7 +24,7 @@ export function defineEnricher(
   } = cdc;
 
   const template = `// This file is generated. Do not edit by hand.
-import {expandTableNames,makeEnricher} from '${runtimeModuleId}';
+import {expandEnvironmentVariables,makeEnricher} from '${runtimeModuleId}';
 import {${handlerImportName}} from '${handlerModuleId}';
 import {
   ${sourceModelName},
@@ -36,7 +36,7 @@ import {
   Update${targetModelName}Input
 } from '${actionsModuleId}';
 
-expandTableNames();
+expandEnvironmentVariables();
 
 export const handler = makeEnricher<
 ${sourceModelName},

--- a/packages/@code-like-a-carpenter/foundation-plugin-cloudformation/src/cdc/lambdas.ts
+++ b/packages/@code-like-a-carpenter/foundation-plugin-cloudformation/src/cdc/lambdas.ts
@@ -179,6 +179,11 @@ export function makeHandler(
     },
     Properties: {
       CodeUri: filename,
+      Environment: {
+        Variables: {
+          FOUNDATION_ENVIRONMENT_VARIABLES: {Ref: 'EnvironmentVariables'},
+        },
+      },
       Events: {
         Stream: {
           Properties: {
@@ -728,6 +733,7 @@ function writeTemplate(config: Config, templatePath: string) {
     Parameters: {
       CodeUri: {Type: 'String'},
       DetailType: {Type: 'CommaDelimitedList'},
+      EnvironmentVariables: {Default: '', Type: 'String'},
       MemorySize: {Type: 'Number'},
       SourceModelName: {Type: 'String'},
       StageName: {Type: 'String'},

--- a/packages/@code-like-a-carpenter/foundation-plugin-cloudformation/src/cdc/reactor.ts
+++ b/packages/@code-like-a-carpenter/foundation-plugin-cloudformation/src/cdc/reactor.ts
@@ -23,11 +23,11 @@ export function defineReactor(
   } = cdc;
 
   const code = `// This file is generated. Do not edit by hand.
-import {expandTableNames, makeReactor} from '${runtimeModuleId}';
+import {expandEnvironmentVariables, makeReactor} from '${runtimeModuleId}';
 import {${handlerImportName}} from '${handlerModuleId}';
 import type {${sourceModelName}, unmarshall${sourceModelName}} from '${actionsModuleId}';
 
-expandTableNames();
+expandEnvironmentVariables();
 
 export const handler = makeReactor<${sourceModelName}>(${handlerImportName}, {unmarshallSourceModel: unmarshall${sourceModelName}});
 `;

--- a/packages/@code-like-a-carpenter/foundation-plugin-cloudformation/src/fragments/table-dispatcher.ts
+++ b/packages/@code-like-a-carpenter/foundation-plugin-cloudformation/src/fragments/table-dispatcher.ts
@@ -49,10 +49,10 @@ export function makeTableDispatcher(
     outputPath,
     `// This file is generated. Do not edit by hand.
 
-import {expandTableNames,makeDynamoDBStreamDispatcher} from '${libImportPath}';
+import {expandEnvironmentVariables,makeDynamoDBStreamDispatcher} from '${libImportPath}';
 import * as dependencies from '${dependenciesModuleId}';
 
-expandTableNames();
+expandEnvironmentVariables();
 
 export const handler = makeDynamoDBStreamDispatcher({
   ...dependencies,
@@ -97,6 +97,11 @@ export const handler = makeDynamoDBStreamDispatcher({
         },
         Properties: {
           CodeUri: codeUri,
+          Environment: {
+            Variables: {
+              FOUNDATION_ENVIRONMENT_VARIABLES: {Ref: 'EnvironmentVariables'},
+            },
+          },
           Events: {
             Stream: {
               Properties: {
@@ -205,6 +210,10 @@ function writeTemplate(config: Config, templatePath: string) {
         Type: 'Number',
       },
       CodeUri: {
+        Type: 'String',
+      },
+      EnvironmentVariables: {
+        Default: '',
         Type: 'String',
       },
       EventBus: {

--- a/packages/@code-like-a-carpenter/foundation-runtime/src/expand-environment-variables.ts
+++ b/packages/@code-like-a-carpenter/foundation-runtime/src/expand-environment-variables.ts
@@ -1,6 +1,6 @@
 import {assert} from '@code-like-a-carpenter/assert';
 
-export function expandTableNames() {
+export function expandEnvironmentVariables() {
   const tableNames = process.env.FOUNDATION_TABLE_NAMES;
   if (tableNames) {
     const tables = JSON.parse(tableNames);
@@ -8,6 +8,18 @@ export function expandTableNames() {
       assert(
         typeof value === 'string',
         'FOUNDATION_TABLE_NAMES should only contain string values'
+      );
+      process.env[key] = value;
+    }
+  }
+
+  const envVars = process.env.FOUNDATION_ENVIRONMENT_VARIABLES;
+  if (envVars) {
+    const env = JSON.parse(envVars);
+    for (const [key, value] of Object.entries(env)) {
+      assert(
+        typeof value === 'string',
+        'FOUNDATION_ENVIRONMENT_VARIABLES should only contain string values'
       );
       process.env[key] = value;
     }

--- a/packages/@code-like-a-carpenter/foundation-runtime/src/index.ts
+++ b/packages/@code-like-a-carpenter/foundation-runtime/src/index.ts
@@ -1,4 +1,4 @@
-export * from './expand-table-names';
+export * from './expand-environment-variables';
 export * from './field-provider';
 export * from './functions/enricher';
 export * from './functions/reactor';


### PR DESCRIPTION
[Finishes #184993937]

I'm not thrilled by this solution, but CloudFormation makes it inconvenient to pass arbitrary values to a nested stack and (as far as  I can tell) all but impossible do do anything with them.

This lets us use `Fn::ToJsonString` to pass an arbitrary map to the nested stack and then that map (as a string) is injected into the Lambda as an environment variable. At initialization, the lambda JSON decodes the map and sets each value on the environment
