### PR TITLE
ci: do deployments outside of the jest lifecycle

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -161,7 +161,21 @@ jobs:
           nodeCount: ${{ matrix.nodeCount }}
           nodeIndex: ${{ matrix.nodeIndex }}
           tests: '{examples,packages}/**/*.test.ts'
-      - run: TEST_ENV=aws npm test -- ${{ steps.split.outputs.tests }}
+      # Deploy all the stacks. Assuming we tuned the matrix correctly, this
+      # _should_ be one stack per job, but we treat it as a list just in case.
+      - run: |
+          PATH=$PATH:$(pwd)/node_modules/.bin ./scripts/crr-sam deploy ${{ steps.split.outputs.tests }}
+        id: deploy
+      - run: npm test -- ${{ steps.split.outputs.tests }}
+        env:
+          # We set RETAIN=true so that the cleanup script can take remove the
+          # stack rather than doing it inside the jest lifecycle.
+          RETAIN: true
+          TEST_ENV: aws
+      # The script keeps track of each stack it deployed so we only attempt to
+      # cleanup stacks that actually exist.
+      - run: ./scripts/crr-sam destroy ${{ steps.deploy.outputs.deployed }}
+        if: ${{ always() }}
       - uses: check-run-reporter/action@v2.11.2
         if: ${{ always() }}
         with:

--- a/jest.d/environments/example.ts
+++ b/jest.d/environments/example.ts
@@ -2,7 +2,6 @@ import '@code-like-a-carpenter/aws-env-loader';
 
 import assert from 'node:assert';
 import {execSync} from 'node:child_process';
-import crypto from 'node:crypto';
 import path from 'node:path';
 
 import {
@@ -14,7 +13,7 @@ import type {
   JestEnvironmentConfig,
 } from '@jest/environment';
 import Environment from 'jest-environment-node';
-import {camelCase, snakeCase, upperFirst} from 'lodash';
+import {snakeCase} from 'lodash';
 
 import {env} from '@code-like-a-carpenter/env';
 
@@ -36,16 +35,12 @@ export default class ExampleEnvironment extends Environment {
       .split(path.sep);
 
     let suffix = '';
-    if (env('GITHUB_REF', '') !== '') {
-      suffix = `-${crypto
-        .createHash('sha256')
-        .update(env('GITHUB_REF'))
-        .digest('hex')
-        .slice(0, 8)}`;
+    if (env('GITHUB_SHA', '') !== '') {
+      suffix = `-${env('GITHUB_SHA', '').slice(0, 7)}`;
     }
 
     this.exampleName = exampleName;
-    this.stackName = upperFirst(camelCase(exampleName)) + suffix;
+    this.stackName = exampleName + suffix;
     process.env.STACK_NAME = this.stackName;
 
     const testEnv = env('TEST_ENV', 'localstack');

--- a/scripts/crr-sam
+++ b/scripts/crr-sam
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+
+action="$1"
+shift
+
+case "$action" in
+  deploy)
+    ;;
+  destroy)
+    ;;
+  *)
+    echo "Unknown action: $action"
+    exit 1
+    ;;
+esac
+
+# This script accepts a list of tests names from Check Run Reporter, filters
+# them down to just examples, and then deploys those stacks
+
+deployed=''
+
+for testfile in "$@"; do
+  if [[ ! "$testfile" =~ ^examples/ ]]; then
+    echo "Skipping $testfile which does not appear to test an AWS stack"
+    continue
+  fi
+
+  example=$(echo "$testfile" | awk -F/ '{print $2}')
+
+  suffix="${GITHUB_SHA:0:7}"
+  stack_name="$example-$suffix"
+
+  STACK_NAME="$stack_name" ./scripts/sam "$action" aws "$example"
+
+  deployed="$deployed $testfile"
+done
+
+
+echo "deployed=$deployed" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Something makes GitHub actions flake when Jest handles deploys. I
cannot currently confirm that deployment is the problem, but it seems
like a good place to start.

[Fixes #184989554]
