### PR TITLE
split examples only

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -86,7 +86,8 @@ jobs:
       - build
       - diff
       - lint
-      - test
+      - test-integration
+      - test-unit
     runs-on: ubuntu-latest
     # This job gets exponentially slower based on the number of packages that
     # need to be release, so 60 is not unreasonable.
@@ -120,7 +121,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  test:
+  test-integration:
     needs: build
     permissions:
       id-token: write
@@ -160,7 +161,7 @@ jobs:
           label: Unit Tests
           nodeCount: ${{ matrix.nodeCount }}
           nodeIndex: ${{ matrix.nodeIndex }}
-          tests: '{examples,packages}/**/*.test.ts'
+          tests: 'examples/**/*.test.ts'
       # Deploy all the stacks. Assuming we tuned the matrix correctly, this
       # _should_ be one stack per job, but we treat it as a list just in case.
       - run: |
@@ -176,6 +177,39 @@ jobs:
       # cleanup stacks that actually exist.
       - run: ./scripts/crr-sam destroy ${{ steps.deploy.outputs.deployed }}
         if: ${{ always() }}
+      - uses: check-run-reporter/action@v2.12.0
+        if: ${{ always() }}
+        with:
+          token: ${{ secrets.CHECK_RUN_REPORTER_TOKEN }}
+          label: Examples
+          nodeCount: ${{ matrix.nodeCount }}
+          nodeIndex: ${{ matrix.nodeIndex }}
+          report: 'reports/junit/**/*.xml'
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: 'reports/coverage'
+
+  test-unit:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3.5.0
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - uses: nrwl/nx-set-shas@v3
+      - run: npm ci
+      # by making this job depend on the build job, the following line should be
+      # 100% cache hits; The nx cache seems to be much easier to use than the
+      # GitHub artifact action.
+      - run: npx nx run-many --target=build --parallel=4
+      - run: npm test -- --selectProjects 'Unit Tests'
       - uses: check-run-reporter/action@v2.12.0
         if: ${{ always() }}
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -154,14 +154,19 @@ jobs:
       # 100% cache hits; The nx cache seems to be much easier to use than the
       # GitHub artifact action.
       - run: npx nx run-many --target=build --parallel=4
-      - uses: check-run-reporter/action@v2.12.0
+      - run: ./scripts/temporary-split
         id: split
-        with:
-          token: ${{ secrets.CHECK_RUN_REPORTER_TOKEN }}
-          label: Unit Tests
-          nodeCount: ${{ matrix.nodeCount }}
-          nodeIndex: ${{ matrix.nodeIndex }}
-          tests: 'examples/**/*.test.ts'
+        env:
+          NODE_COUNT: ${{ matrix.nodeCount }}
+          NODE_INDEX: ${{ matrix.nodeIndex }}
+      #      - uses: check-run-reporter/action@v2.12.0
+      #        id: split
+      #        with:
+      #          token: ${{ secrets.CHECK_RUN_REPORTER_TOKEN }}
+      #          label: Unit Tests
+      #          nodeCount: ${{ matrix.nodeCount }}
+      #          nodeIndex: ${{ matrix.nodeIndex }}
+      #          tests: 'examples/**/*.test.ts'
       # Deploy all the stacks. Assuming we tuned the matrix correctly, this
       # _should_ be one stack per job, but we treat it as a list just in case.
       - run: |

--- a/scripts/crr-sam
+++ b/scripts/crr-sam
@@ -38,5 +38,9 @@ for testfile in "$@"; do
   deployed="$deployed $testfile"
 done
 
+if [ -z "$deployed" ]; then
+  echo "::error title=CI Misconfiguration::No stacks deployed"
+  exit 1
+fi
 
 echo "deployed=$deployed" >> "$GITHUB_OUTPUT"

--- a/scripts/temporary-split
+++ b/scripts/temporary-split
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+tests=$(find examples -name '*.test.ts')
+
+if (( $(echo $tests | wc -w) != $NODE_COUNT )); then
+  echo "::error title=CI Misconfiguration::Expected $NODE_COUNT tests, but found $(echo $tests | wc -w)"
+  exit 1
+fi
+
+if (( $NODE_COUNT <= $NODE_INDEX )); then
+  echo "::error title=CI Misconfiguration::Expected NODE_INDEX ($NODE_INDEX) to be less than NODE_COUNT ($NODE_COUNT)"
+fi
+
+index=$((NODE_INDEX+1))
+
+# word splitting is intentional
+# shellcheck disable=SC2086
+tests_for_this_node=$(echo $tests | cut -d ' ' -f "$index")
+
+echo "tests=${tests_for_this_node}" >> "$GITHUB_OUTPUT"
+echo "${tests_for_this_node} should be run on this node ($NODE_INDEX, $NODE_COUNT)" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
- ci(github): split unit tests from example tests
- ci: manually split examples due to CRR bug
- ci: fail fast if no stacks are specified
