### PR TITLE
fixes

### DIFF
--- a/packages/@code-like-a-carpenter/assert/src/assert.ts
+++ b/packages/@code-like-a-carpenter/assert/src/assert.ts
@@ -26,13 +26,17 @@ export function assert(
 export {
   deepEqual,
   deepStrictEqual,
-  doesNotMatch,
+  // Removing the next line for now because it's missing from esbuild's node
+  // builtins polyfill
+  // doesNotMatch,
   doesNotReject,
   doesNotThrow,
   equal,
   fail,
   ifError,
-  match,
+  // Removing the next line for now because it's missing from esbuild's node
+  // builtins polyfill
+  // match,
   notDeepEqual,
   notDeepStrictEqual,
   notEqual,

--- a/packages/@code-like-a-carpenter/foundation-plugin-cloudformation/src/transforms.ts
+++ b/packages/@code-like-a-carpenter/foundation-plugin-cloudformation/src/transforms.ts
@@ -26,12 +26,10 @@ export async function applyTransforms(
  * Deals with the possibility that this code may run in commonjs or esm mode.
  */
 async function loadTransform(transformModule: string): Promise<Transform> {
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const {transform} = require(transformModule);
-    return transform;
-  } catch (err) {
-    const {transform} = await import(transformModule);
-    return transform;
+  const mod = await import(transformModule);
+  if (mod.default) {
+    return mod.default.transform;
   }
+
+  return mod.transform;
 }


### PR DESCRIPTION
- fix(assert): do not export assertions that esbuild does not polyfill
- fix(foundation-plugin-cloudformation): always use await import to load transforms
- fix: stop releasing cjs versions of cli-oriented modules
