### PR TITLE
fix(cli-core): always use await import to load plugins

### DIFF
--- a/packages/@code-like-a-carpenter/cli-core/src/index.ts
+++ b/packages/@code-like-a-carpenter/cli-core/src/index.ts
@@ -30,14 +30,12 @@ export async function main() {
 }
 
 async function load(pluginName: string) {
-  try {
-    const {default: plugin} = await import(pluginName);
-    return plugin;
-  } catch (err) {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const {default: plugin} = require(pluginName);
-    return plugin;
+  const mod = await import(pluginName);
+  if (mod.default) {
+    return mod.default.transform;
   }
+
+  return mod.transform;
 }
 
 export async function registerPlugin(yargs: Argv, fn: RegisterPluginFunction) {


### PR DESCRIPTION
require basically cannot work anymore. await import _should_ always be available.
