### PR TITLE
cli stack name

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -21,6 +21,7 @@ declare global {
 const commonProjectConfig: Partial<Config.ProjectConfig> = {
   clearMocks: true,
   modulePathIgnorePatterns: ['.nx/'],
+  prettierPath: require.resolve('prettier-2'),
   setupFilesAfterEnv: ['./jest.d/setup-files-after-env/faker.ts'],
   testEnvironment: 'node',
   testPathIgnorePatterns: ['/dist/', '/node_modules/'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "openapi-typescript": "^6.7.4",
         "patch-package": "^8.0.0",
         "prettier": "^3.2.5",
+        "prettier-2": "npm:prettier@^2",
         "tsx": "^4.7.0",
         "typescript": "^5.3.3",
         "wait-on": "^7.1.0"
@@ -22589,6 +22590,22 @@
       },
       "engines": {
         "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-2": {
+      "name": "prettier",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3405,6 +3405,10 @@
       "resolved": "packages/@code-like-a-carpenter/cli-plugin-proxy",
       "link": true
     },
+    "node_modules/@code-like-a-carpenter/cli-plugin-stack-name": {
+      "resolved": "packages/@code-like-a-carpenter/cli-plugin-stack-name",
+      "link": true
+    },
     "node_modules/@code-like-a-carpenter/contract-tests": {
       "resolved": "packages/@code-like-a-carpenter/contract-tests",
       "link": true
@@ -26852,6 +26856,7 @@
         "@code-like-a-carpenter/cli-core": "*",
         "@code-like-a-carpenter/cli-plugin-example": "*",
         "@code-like-a-carpenter/cli-plugin-proxy": "*",
+        "@code-like-a-carpenter/cli-plugin-stack-name": "*",
         "@code-like-a-carpenter/tooling-deps": "*"
       },
       "bin": {
@@ -26910,6 +26915,19 @@
         "@types/http-proxy": "^1.17.14",
         "@types/lodash.snakecase": "^4.1.9",
         "@types/vhost": "^3.0.9"
+      },
+      "engines": {
+        "node": "20.x"
+      }
+    },
+    "packages/@code-like-a-carpenter/cli-plugin-stack-name": {
+      "license": "MIT",
+      "dependencies": {
+        "@code-like-a-carpenter/cli-core": "*",
+        "@code-like-a-carpenter/tooling-common": "*"
+      },
+      "bin": {
+        "cli-plugin-stack-name": "cli.mjs"
       },
       "engines": {
         "node": "20.x"

--- a/package-lock.json
+++ b/package-lock.json
@@ -27216,6 +27216,7 @@
       "license": "MIT",
       "dependencies": {
         "@code-like-a-carpenter/env": "*",
+        "ci-info": "^4.0.0",
         "find-up": "^5.0.0",
         "glob": "^10.3.10",
         "lodash.camelcase": "^4.3.0",
@@ -27227,6 +27228,20 @@
       },
       "engines": {
         "node": "20.x"
+      }
+    },
+    "packages/@code-like-a-carpenter/tooling-common/node_modules/ci-info": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz",
+      "integrity": "sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "engines": {
+        "node": ">=8"
       }
     },
     "packages/@code-like-a-carpenter/tooling-deps": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "openapi-typescript": "^6.7.4",
     "patch-package": "^8.0.0",
     "prettier": "^3.2.5",
+    "prettier-2": "npm:prettier@^2",
     "tsx": "^4.7.0",
     "typescript": "^5.3.3",
     "wait-on": "^7.1.0"

--- a/packages/@code-like-a-carpenter/cli-plugin-stack-name/README.md
+++ b/packages/@code-like-a-carpenter/cli-plugin-stack-name/README.md
@@ -1,0 +1,34 @@
+# @code-like-a-carpenter/cli-plugin-stack-name
+
+[![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
+
+> Converts an input string to a stack name
+
+## Table of Contents
+
+-   [Install](#install)
+-   [Usage](#usage)
+-   [Maintainer](#maintainer)
+-   [Contributing](#contributing)
+-   [License](#license)
+
+## Install
+
+```bash
+npm i @code-like-a-carpenter/cli-plugin-stack-name
+```
+
+## Usage
+
+## Maintainer
+
+[Ian Remmel](https://www.ianwremmel.com)
+
+## Contributing
+
+Please see contributing guidelines at the
+[project homepage](https://www.github.com/code-like-a-carpenter/workbench/).
+
+## License
+
+MIT © [Ian Remmel](https://www.ianwremmel.com) 2023 until at least now

--- a/packages/@code-like-a-carpenter/cli-plugin-stack-name/package.json
+++ b/packages/@code-like-a-carpenter/cli-plugin-stack-name/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@code-like-a-carpenter/cli-plugin-stack-name",
+  "description": "Converts an input string to a stack name",
+  "dependencies": {
+    "@code-like-a-carpenter/cli-core": "*",
+    "@code-like-a-carpenter/tooling-common": "*"
+  },
+  "author": "Ian Remmel <1182361+ianwremmel@users.noreply.github.com> (https://www.ianwremmel.com)",
+  "bugs": "https://www.github.com/code-like-a-carpenter/workbench/issues",
+  "engines": {
+    "node": "20.x"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "development": "./src/index.ts",
+      "import": "./dist/esm/index.mjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "homepage": "https://www.github.com/code-like-a-carpenter/workbench/tree/main/packages/@code-like-a-carpenter/cli-plugin-stack-name",
+  "license": "MIT",
+  "repository": "git@github.com:code-like-a-carpenter/workbench.git",
+  "types": "dist/types",
+  "publishConfig": {
+    "access": "public"
+  },
+  "bin": "./cli.mjs",
+  "releaseAll": 1
+}

--- a/packages/@code-like-a-carpenter/cli-plugin-stack-name/src/__snapshots__/index.test.ts.snap
+++ b/packages/@code-like-a-carpenter/cli-plugin-stack-name/src/__snapshots__/index.test.ts.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`cli-plugin-stack-name formats a stack name 1`] = `"CodeLikeACarpenterToolingCommon"`;
+
+exports[`cli-plugin-stack-name formats a stack name 2`] = `"CodeLikeACarpenterFoundationIntermediateRepresentation"`;
+
+exports[`cli-plugin-stack-name formats a stack name 3`] = `"AwsOtel"`;
+
+exports[`cli-plugin-stack-name formats a stack name 4`] = `"CheckRunReporter"`;
+
+exports[`cli-plugin-stack-name formats a stack name in ci 1`] = `"ci--CodeLikeACarpenterToolingCommon-f7d69db"`;
+
+exports[`cli-plugin-stack-name formats a stack name in ci 2`] = `"ci--CodeLikeACarpenterToolingCommon-openapiTypescript6-f7d69db"`;
+
+exports[`cli-plugin-stack-name formats a stack name in ci 3`] = `"ci--CodeLikeACarpenterToolingCommon-openapiTypescript6-f7d69db"`;
+
+exports[`cli-plugin-stack-name formats a stack name in ci 4`] = `"ci--CodeLikeACarpenterToolingCommon-f7d69db"`;
+
+exports[`cli-plugin-stack-name formats a stack name in ci 5`] = `"ci--CodeLikeACarpenterToolingCommon-openapiTypescript6-f7d69db"`;
+
+exports[`cli-plugin-stack-name formats a stack name in ci 6`] = `"ci--CodeLikeACarpenterFoundationIntermediateRepresentation-f7d69db"`;
+
+exports[`cli-plugin-stack-name formats a stack name in ci 7`] = `"ci--CodeLikeACarpenterFoundationIntermediateRepresentation-openapiTypescript6-f7d69db"`;
+
+exports[`cli-plugin-stack-name formats a stack name in ci 8`] = `"ci--CodeLikeACarpenterFoundationIntermediateRepresentation-openapiTypescript6-f7d69db"`;
+
+exports[`cli-plugin-stack-name formats a stack name in ci 9`] = `"ci--CodeLikeACarpenterFoundationIntermediateRepresentation-f7d69db"`;
+
+exports[`cli-plugin-stack-name formats a stack name in ci 10`] = `"ci--CodeLikeACarpenterFoundationIntermediateRepresentation-openapiTypescript6-f7d69db"`;
+
+exports[`cli-plugin-stack-name formats a stack name in ci 11`] = `"ci--AwsOtel-f7d69db"`;
+
+exports[`cli-plugin-stack-name formats a stack name in ci 12`] = `"ci--AwsOtel-openapiTypescript6-f7d69db"`;
+
+exports[`cli-plugin-stack-name formats a stack name in ci 13`] = `"ci--AwsOtel-openapiTypescript6-f7d69db"`;
+
+exports[`cli-plugin-stack-name formats a stack name in ci 14`] = `"ci--AwsOtel-f7d69db"`;
+
+exports[`cli-plugin-stack-name formats a stack name in ci 15`] = `"ci--AwsOtel-openapiTypescript6-f7d69db"`;
+
+exports[`cli-plugin-stack-name formats a stack name in ci 16`] = `"ci--CheckRunReporter-f7d69db"`;
+
+exports[`cli-plugin-stack-name formats a stack name in ci 17`] = `"ci--CheckRunReporter-openapiTypescript6-f7d69db"`;
+
+exports[`cli-plugin-stack-name formats a stack name in ci 18`] = `"ci--CheckRunReporter-openapiTypescript6-f7d69db"`;
+
+exports[`cli-plugin-stack-name formats a stack name in ci 19`] = `"ci--CheckRunReporter-f7d69db"`;
+
+exports[`cli-plugin-stack-name formats a stack name in ci 20`] = `"ci--CheckRunReporter-openapiTypescript6-f7d69db"`;

--- a/packages/@code-like-a-carpenter/cli-plugin-stack-name/src/index.test.ts
+++ b/packages/@code-like-a-carpenter/cli-plugin-stack-name/src/index.test.ts
@@ -1,0 +1,55 @@
+import {execSync} from 'node:child_process';
+
+const GITHUB_HEAD_REF = 'dependabot/npm_and_yarn/openapi-typescript-6.7.4';
+const GITHUB_REF =
+  'refs/heads/dependabot/npm_and_yarn/openapi-typescript-6.7.4';
+const GITHUB_SHA = 'f7d69db466396454e27435e3dc4affde6a1f3263';
+const BUILDKITE_BRANCH = 'dependabot/npm_and_yarn/openapi-typescript-6.7.4';
+const BUILDKITE_COMMIT = 'f7d69db466396454e27435e3dc4affde6a1f3263';
+
+const gitData = [
+  {GITHUB_ACTIONS: 'true', GITHUB_SHA},
+  {GITHUB_ACTIONS: 'true', GITHUB_HEAD_REF, GITHUB_SHA},
+  {GITHUB_ACTIONS: 'true', GITHUB_REF, GITHUB_SHA},
+  {BUILDKITE: 'true', BUILDKITE_COMMIT},
+  {BUILDKITE: 'true', BUILDKITE_BRANCH, BUILDKITE_COMMIT},
+];
+
+const projectNames = [
+  '@code-like-a-carpenter/tooling-common',
+  '@code-like-a-carpenter/foundation-intermediate-representation',
+  'aws-otel',
+  'check-run-reporter',
+];
+
+const testData = projectNames
+  .map((projectName) => gitData.map((env) => [projectName, env] as const))
+  .flat(1);
+
+describe('cli-plugin-stack-name', () => {
+  it.each(projectNames)('formats a stack name', async (projectName) => {
+    const result = execSync(
+      `npx @code-like-a-carpenter/cli stack-name ${projectName}`,
+      {env: {NODE_OPTIONS: process.env.NODE_OPTIONS, PATH: process.env.PATH}}
+    );
+    const stackName = result.toString().trim();
+    expect(stackName).toMatchSnapshot();
+  });
+
+  it.each(testData)('formats a stack name in ci', async (projectName, env) => {
+    const result = execSync(
+      `npx @code-like-a-carpenter/cli stack-name ${projectName}`,
+      {
+        env: {
+          ...env,
+          NODE_OPTIONS: process.env.NODE_OPTIONS,
+          PATH: process.env.PATH,
+        },
+      }
+    );
+    const stackName = result.toString().trim();
+    expect(stackName).toMatchSnapshot();
+    expect(stackName).toMatch(/^ci--/);
+    expect(stackName.length).toBeLessThan(128);
+  });
+});

--- a/packages/@code-like-a-carpenter/cli-plugin-stack-name/src/index.ts
+++ b/packages/@code-like-a-carpenter/cli-plugin-stack-name/src/index.ts
@@ -1,0 +1,16 @@
+import {definePlugin} from '@code-like-a-carpenter/cli-core';
+import {getStackName} from '@code-like-a-carpenter/tooling-common';
+
+export default definePlugin((yargs) => {
+  yargs.command({
+    builder: (y) =>
+      y.positional('projectName', {
+        demandOption: true,
+        type: 'string',
+      }),
+    command: 'stack-name <projectName>',
+    async handler(argv) {
+      console.log(getStackName(argv.projectName));
+    },
+  });
+});

--- a/packages/@code-like-a-carpenter/cli-plugin-stack-name/tsconfig.json
+++ b/packages/@code-like-a-carpenter/cli-plugin-stack-name/tsconfig.json
@@ -10,16 +10,7 @@
       "path": "../cli-core"
     },
     {
-      "path": "../cli-plugin-example"
-    },
-    {
-      "path": "../cli-plugin-proxy"
-    },
-    {
-      "path": "../cli-plugin-stack-name"
-    },
-    {
-      "path": "../tooling-deps"
+      "path": "../tooling-common"
     }
   ]
 }

--- a/packages/@code-like-a-carpenter/cli/package.json
+++ b/packages/@code-like-a-carpenter/cli/package.json
@@ -19,6 +19,7 @@
     "plugins": [
       "@code-like-a-carpenter/cli-plugin-example",
       "@code-like-a-carpenter/cli-plugin-proxy",
+      "@code-like-a-carpenter/cli-plugin-stack-name",
       "@code-like-a-carpenter/tooling-deps"
     ]
   },
@@ -26,6 +27,7 @@
     "@code-like-a-carpenter/cli-core": "*",
     "@code-like-a-carpenter/cli-plugin-example": "*",
     "@code-like-a-carpenter/cli-plugin-proxy": "*",
+    "@code-like-a-carpenter/cli-plugin-stack-name": "*",
     "@code-like-a-carpenter/tooling-deps": "*"
   },
   "exports": {

--- a/packages/@code-like-a-carpenter/tooling-common/package.json
+++ b/packages/@code-like-a-carpenter/tooling-common/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@code-like-a-carpenter/env": "*",
+    "ci-info": "^4.0.0",
     "find-up": "^5.0.0",
     "glob": "^10.3.10",
     "lodash.camelcase": "^4.3.0",

--- a/packages/@code-like-a-carpenter/tooling-common/src/__snapshots__/format-stack-name.test.ts.snap
+++ b/packages/@code-like-a-carpenter/tooling-common/src/__snapshots__/format-stack-name.test.ts.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`formatStackName() converts a project name to a stack name 1`] = `"CodeLikeACarpenterToolingCommon"`;
+
+exports[`formatStackName() converts a project name to a stack name 2`] = `"CodeLikeACarpenterFoundationIntermediateRepresentation"`;
+
+exports[`formatStackName() converts a project name to a stack name 3`] = `"AwsOtel"`;
+
+exports[`formatStackName() converts a project name to a stack name 4`] = `"CheckRunReporter"`;
+
+exports[`formatStackName() converts a project name to a stack name in ci 1`] = `"ci--CodeLikeACarpenterToolingCommon-f7d69db"`;
+
+exports[`formatStackName() converts a project name to a stack name in ci 2`] = `"ci--CodeLikeACarpenterToolingCommon-openapiTypescript6-f7d69db"`;
+
+exports[`formatStackName() converts a project name to a stack name in ci 3`] = `"ci--CodeLikeACarpenterToolingCommon-openapiTypescript6-f7d69db"`;
+
+exports[`formatStackName() converts a project name to a stack name in ci 4`] = `"ci--CodeLikeACarpenterToolingCommon-f7d69db"`;
+
+exports[`formatStackName() converts a project name to a stack name in ci 5`] = `"ci--CodeLikeACarpenterToolingCommon-openapiTypescript6-f7d69db"`;
+
+exports[`formatStackName() converts a project name to a stack name in ci 6`] = `"ci--CodeLikeACarpenterFoundationIntermediateRepresentation-f7d69db"`;
+
+exports[`formatStackName() converts a project name to a stack name in ci 7`] = `"ci--CodeLikeACarpenterFoundationIntermediateRepresentation-openapiTypescript6-f7d69db"`;
+
+exports[`formatStackName() converts a project name to a stack name in ci 8`] = `"ci--CodeLikeACarpenterFoundationIntermediateRepresentation-openapiTypescript6-f7d69db"`;
+
+exports[`formatStackName() converts a project name to a stack name in ci 9`] = `"ci--CodeLikeACarpenterFoundationIntermediateRepresentation-f7d69db"`;
+
+exports[`formatStackName() converts a project name to a stack name in ci 10`] = `"ci--CodeLikeACarpenterFoundationIntermediateRepresentation-openapiTypescript6-f7d69db"`;
+
+exports[`formatStackName() converts a project name to a stack name in ci 11`] = `"ci--AwsOtel-f7d69db"`;
+
+exports[`formatStackName() converts a project name to a stack name in ci 12`] = `"ci--AwsOtel-openapiTypescript6-f7d69db"`;
+
+exports[`formatStackName() converts a project name to a stack name in ci 13`] = `"ci--AwsOtel-openapiTypescript6-f7d69db"`;
+
+exports[`formatStackName() converts a project name to a stack name in ci 14`] = `"ci--AwsOtel-f7d69db"`;
+
+exports[`formatStackName() converts a project name to a stack name in ci 15`] = `"ci--AwsOtel-openapiTypescript6-f7d69db"`;
+
+exports[`formatStackName() converts a project name to a stack name in ci 16`] = `"ci--CheckRunReporter-f7d69db"`;
+
+exports[`formatStackName() converts a project name to a stack name in ci 17`] = `"ci--CheckRunReporter-openapiTypescript6-f7d69db"`;
+
+exports[`formatStackName() converts a project name to a stack name in ci 18`] = `"ci--CheckRunReporter-openapiTypescript6-f7d69db"`;
+
+exports[`formatStackName() converts a project name to a stack name in ci 19`] = `"ci--CheckRunReporter-f7d69db"`;
+
+exports[`formatStackName() converts a project name to a stack name in ci 20`] = `"ci--CheckRunReporter-openapiTypescript6-f7d69db"`;

--- a/packages/@code-like-a-carpenter/tooling-common/src/format-stack-name.test.ts
+++ b/packages/@code-like-a-carpenter/tooling-common/src/format-stack-name.test.ts
@@ -41,6 +41,7 @@ describe('formatStackName()', () => {
     (projectName, env) => {
       const stackName = formatStackName({projectName, ...env});
       expect(stackName).toMatchSnapshot();
+      expect(stackName).toMatch(/^ci--/);
       expect(stackName.length).toBeLessThan(128);
     }
   );

--- a/packages/@code-like-a-carpenter/tooling-common/src/format-stack-name.test.ts
+++ b/packages/@code-like-a-carpenter/tooling-common/src/format-stack-name.test.ts
@@ -1,0 +1,47 @@
+import {formatStackName} from './format-stack-name';
+
+const GITHUB_HEAD_REF = 'dependabot/npm_and_yarn/openapi-typescript-6.7.4';
+const GITHUB_REF =
+  'refs/heads/dependabot/npm_and_yarn/openapi-typescript-6.7.4';
+const GITHUB_SHA = 'f7d69db466396454e27435e3dc4affde6a1f3263';
+const BUILDKITE_BRANCH = 'dependabot/npm_and_yarn/openapi-typescript-6.7.4';
+const BUILDKITE_COMMIT = 'f7d69db466396454e27435e3dc4affde6a1f3263';
+
+const gitData = [
+  {ci: true, sha: GITHUB_SHA},
+  {ci: true, fullRef: GITHUB_HEAD_REF, sha: GITHUB_SHA},
+  {ci: true, ref: GITHUB_REF, sha: GITHUB_SHA},
+  {ci: true, sha: BUILDKITE_COMMIT},
+  {ci: true, ref: BUILDKITE_BRANCH, sha: BUILDKITE_COMMIT},
+];
+
+const projectNames = [
+  '@code-like-a-carpenter/tooling-common',
+  '@code-like-a-carpenter/foundation-intermediate-representation',
+  'aws-otel',
+  'check-run-reporter',
+];
+
+const testData = projectNames
+  .map((projectName) => gitData.map((env) => [projectName, env] as const))
+  .flat(1);
+
+describe('formatStackName()', () => {
+  it.each(projectNames)(
+    'converts a project name to a stack name',
+    (projectName) => {
+      const stackName = formatStackName({ci: false, projectName});
+      expect(stackName).toMatchSnapshot();
+      expect(stackName.length).toBeLessThan(128);
+    }
+  );
+
+  it.each(testData)(
+    'converts a project name to a stack name in ci',
+    (projectName, env) => {
+      const stackName = formatStackName({projectName, ...env});
+      expect(stackName).toMatchSnapshot();
+      expect(stackName.length).toBeLessThan(128);
+    }
+  );
+});

--- a/packages/@code-like-a-carpenter/tooling-common/src/format-stack-name.ts
+++ b/packages/@code-like-a-carpenter/tooling-common/src/format-stack-name.ts
@@ -1,0 +1,45 @@
+import camelCase from 'lodash.camelcase';
+import upperFirst from 'lodash.upperfirst';
+
+export interface FormatStackNameOptions {
+  readonly ci: boolean;
+  readonly fullRef?: string;
+  readonly projectName: string;
+  readonly sha?: string;
+  readonly ref?: string;
+}
+export function formatStackName({
+  ci,
+  fullRef = '',
+  projectName,
+  sha = '',
+  ref = '',
+}: FormatStackNameOptions): string {
+  const stackName = upperFirst(camelCase(projectName));
+  let suffix = '';
+
+  if (!ci) {
+    return stackName;
+  }
+
+  if (sha !== '') {
+    suffix = sha.slice(0, 7);
+  }
+
+  let branch = '';
+  if (fullRef !== '') {
+    branch = fullRef;
+  } else if (ref) {
+    branch = ref.split('/').slice(2).join('/');
+  }
+
+  if (branch) {
+    if (branch.startsWith('dependabot')) {
+      branch = branch.split('/').slice(2).join('/');
+    }
+
+    suffix = `${camelCase(branch.replace(/[/_]/g, '-').substring(0, 20))}-${suffix}`;
+  }
+
+  return `ci--${suffix ? `${stackName}-${suffix}` : stackName}`;
+}

--- a/packages/@code-like-a-carpenter/tooling-common/src/get-stack-name.ts
+++ b/packages/@code-like-a-carpenter/tooling-common/src/get-stack-name.ts
@@ -16,7 +16,7 @@ export function getStackName(projectName: string): string {
     return formatStackName({
       ci: true,
       projectName,
-      ref: env('BUILDKITE_BRANCH'),
+      ref: env('BUILDKITE_BRANCH', ''),
       sha: env('BUILDKITE_COMMIT'),
     });
   }
@@ -24,9 +24,9 @@ export function getStackName(projectName: string): string {
   if (ci.GITHUB_ACTIONS) {
     return formatStackName({
       ci: true,
-      fullRef: env('GITHUB_HEAD_REF'),
+      fullRef: env('GITHUB_HEAD_REF', ''),
       projectName,
-      ref: env('GITHUB_REF'),
+      ref: env('GITHUB_REF', ''),
       sha: env('GITHUB_SHA'),
     });
   }

--- a/scripts/sam
+++ b/scripts/sam
@@ -160,7 +160,6 @@ destroy_one () {
 }
 
 get_stack_name () {
-
   if [ -n "${STACK_NAME:-}" ]; then
     echo "$STACK_NAME"
     return 0
@@ -168,32 +167,7 @@ get_stack_name () {
 
   local app="$1"
 
-  local stackname
-  # This PascalCases the last item in the path.
-  project_name=$(echo "$app" | awk -F/ '{print $NF}')
-  stackname=$(echo "$project_name" | sed -r 's/(^|[-_ ]+)([0-9a-z])/\U\2/g')
-
-  local suffix=''
-  if [ -n "${GITHUB_SHA:-}" ]; then
-    suffix="${GITHUB_SHA:0:7}"
-  fi
-
-  if [ -n "${GITHUB_HEAD_REF:-}" ]; then
-    # If we have a GITHUB_HEAD_REF, replace its slashes and underscores with
-    # hyphens and take the first 20 characters
-    suffix="$suffix-$(echo "$GITHUB_HEAD_REF" | sed -e 's#[/_]#-#g' | head -c 20)"
-  elif [ -n "${GITHUB_REF:-}" ]; then
-    # If we have a GITHUB_REF, remove the refs/heads/ prefix, replace its
-    # slashes and underscores with hyphens and take the first 20 characters
-    branch_name=$(echo "$GITHUB_REF" | cut -d '/' -f 3- | sed -e 's#[/_]#-#g' | head -c 20)
-    suffix="$suffix-$branch_name"
-  fi
-
-  if [ -z "$suffix" ]; then
-    echo "$stackname"
-  else
-    echo "$stackname-$suffix"
-  fi
+  npx ---no-install @code-like-a-carpenter/cli stack-name "$app"
 
   return 0
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,6 +40,9 @@
       "path": "packages/@code-like-a-carpenter/cli-plugin-proxy"
     },
     {
+      "path": "packages/@code-like-a-carpenter/cli-plugin-stack-name"
+    },
+    {
       "path": "packages/@code-like-a-carpenter/contract-tests"
     },
     {


### PR DESCRIPTION
- chore: add prettier@2 for jest
- feat(tooling-comming): add well-tested helper for determining stack name
- refactor(tooling-common): make getStackName rely on ci-info and formatStackName
- feat(cli): add stack-name plugin
- build: use stack name cli for all stack name determination
